### PR TITLE
fix: change children of box in chapter example to be triggers

### DIFF
--- a/Assets/Innoactive/Creator/Examples/Scenes/Advanced/ChaptersExample.unity
+++ b/Assets/Innoactive/Creator/Examples/Scenes/Advanced/ChaptersExample.unity
@@ -2815,7 +2815,7 @@ GameObject:
   - component: {fileID: 1895291190198849}
   - component: {fileID: 1895291190198848}
   m_Layer: 0
-  m_Name: Cube_2
+  m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Innoactive/Creator/Examples/Scenes/Advanced/ChaptersExample.unity
+++ b/Assets/Innoactive/Creator/Examples/Scenes/Advanced/ChaptersExample.unity
@@ -680,7 +680,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 518914474}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
@@ -1885,7 +1885,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1230724019}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
@@ -2084,7 +2084,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1620680581}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
@@ -2234,7 +2234,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1897303815}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
@@ -2497,7 +2497,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2078854303}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
@@ -2815,7 +2815,7 @@ GameObject:
   - component: {fileID: 1895291190198849}
   - component: {fileID: 1895291190198848}
   m_Layer: 0
-  m_Name: Cube
+  m_Name: Cube_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0


### PR DESCRIPTION
### Description
In the chapters example the workflow showed an error because the child objects of the Box were not trigger collider which is required by the Object in Collider condition